### PR TITLE
Reversed item iteration.

### DIFF
--- a/ForceDrop.cs
+++ b/ForceDrop.cs
@@ -58,7 +58,7 @@ namespace ForceDrop
                         {
                             var count = player.Inventory.getItemCount(page);
 
-                            for (byte index = 0; index < count; index++)
+                            for (byte index = count; index --> 0;)
                             {
                                 foreach (var number in Configuration.Instance.WhiteListedFromDrop)
                                 {
@@ -83,7 +83,7 @@ namespace ForceDrop
                         {
                             var count = player.Inventory.getItemCount(page);
 
-                            for (byte index = 0; index < count; index++)
+                            for (byte index = count; index --> 0;)
                             {
                                 if (player.Inventory.getItem(page, index).item.id == ushort.Parse(command[1].ToString()))
                                 {
@@ -105,7 +105,7 @@ namespace ForceDrop
                     {
                         var count = player.Inventory.getItemCount(page);
 
-                        for (byte index = 0; index < count; index++)
+                        for (byte index = count; index --> 0;)
                         {
                             foreach (var number in Configuration.Instance.WhiteListedFromDrop)
                             {
@@ -130,7 +130,7 @@ namespace ForceDrop
                     {
                         var count = player.Inventory.getItemCount(page);
 
-                        for (byte index = 0; index < count; index++)
+                        for (byte index = count; index --> 0;)
                         {
                             if (player.Inventory.getItem(page, index).item.id == ushort.Parse(command[1].ToString()))
                             {


### PR DESCRIPTION
Iterating from forwards is a bad idea when you are also removing the items as the indices will shift and you will skip over items. Here's an example of the current behavior: https://i.imgur.com/3W8msXm.png

This reverses the loop and fixes that issue, example: https://i.imgur.com/LScMeqt.png

Fixes #1 